### PR TITLE
Allow to configure Net::HTTP read_timeout and open_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 Hatena Fotolife API requires user authentication with OAuth.
 So you need to get OAuth 1.0a keys and consumer tokens before using this gem.
 
-### 1. Get consumer_key & consumer_secret 
+### 1. Get consumer_key & consumer_secret
 Get consumer_key and consumer_secret from [Hatena Developer Center](https://www.hatena.ne.jp/rlho/config/auth/develop)
 
 ### 2. Get access_token & access_token_secret
@@ -41,6 +41,9 @@ consumer_key: <Hatena application consumer key>
 consumer_secret: <Hatena application consumer secret>
 access_token: <Hatena application access token>
 access_token_secret: <Hatena application access token secret>
+consumer_options:
+  timeout: 300
+  open_timeout: 60
 ```
 
 2. Run

--- a/lib/hatena_fotolife/requester.rb
+++ b/lib/hatena_fotolife/requester.rb
@@ -9,7 +9,7 @@ module HatenaFotolife
     class RequestError < StandardError; end
 
     def self.create(config)
-      consumer = ::OAuth::Consumer.new(config.consumer_key, config.consumer_secret)
+      consumer = ::OAuth::Consumer.new(config.consumer_key, config.consumer_secret, config.consumer_options || {})
       Requester::OAuth.new(::OAuth::AccessToken.new(consumer, config.access_token, config.access_token_secret))
     end
 


### PR DESCRIPTION
With the Net::HTTP default  `read_timeout` (30sec in case of oauth gem), sometimes timeout happens to upload large images to hatena diary. This PR allows to configure Net::HTTP read_timeout and open_timeout.

We can find available options by reading consumer.rb of oauth gem such as https://github.com/oauth-xx/oauth-ruby/blob/200b109736c4ac8609e77c7b536e429e0b2522fe/lib/oauth/consumer.rb#L354-L355 although the oauth gem does not have a document to state available options clearly. 
