### PR TITLE
(fix): Change return value of document at post_image

### DIFF
--- a/lib/hatena_fotolife/client.rb
+++ b/lib/hatena_fotolife/client.rb
@@ -31,7 +31,7 @@ module HatenaFotolife
     # Post a image.
     # @param [String] title entry title
     # @param [String] content entry content
-    # @return [HatenaImage::Image] posted image
+    # @return [String] URI of posted image
     def post_image(title: nil, file_path:, subject: nil)
       title = File.basename(file_path, '.*') unless title
       content = Base64.encode64(open(file_path).read)


### PR DESCRIPTION
The document shows return `HatenaImage::Image`, but the implementation return String as URI of the posted image.
This commit fixes the document of return value at post_image.

related: #9
closed: #18